### PR TITLE
Fixed blood moon double hemogen drain with multiple maps, slight other changes

### DIFF
--- a/1.4/Source/VanillaRacesExpanded-Sanguophage/VanillaRacesExpanded-Sanguophage/Harmony/GeneResourceDrainUtility_OffsetResource.cs
+++ b/1.4/Source/VanillaRacesExpanded-Sanguophage/VanillaRacesExpanded-Sanguophage/Harmony/GeneResourceDrainUtility_OffsetResource.cs
@@ -19,23 +19,15 @@ namespace VanillaRacesExpandedSanguophage
 
     static class VanillaRacesExpandedSanguophage_GeneResourceDrainUtility_OffsetResource_Apply_Patch
     {
-       
-        [HarmonyPostfix]
-        public static void DoubleHemogenLoss(IGeneResourceDrain drain, float amnt)
+
+        [HarmonyPrefix]
+        public static void DoubleHemogenLoss(IGeneResourceDrain drain, ref float amnt)
         {
-            if (Current.Game?.CurrentMap?.GameConditionManager?.ConditionIsActive(InternalDefOf.VRE_BloodMoonCondition)==true) {
+            if (drain.Pawn?.Map?.GameConditionManager?.ConditionIsActive(InternalDefOf.VRE_BloodMoonCondition) == true) {
                 if (amnt < 0) {
-                    float value = drain.Resource.Value;
-                    drain.Resource.Value += amnt;
-                    GeneResourceDrainUtility.PostResourceOffset(drain, value);
+                    amnt *= 2;
                 }
-                    
-                
-
             }
-            
-            
-
         }
 
 


### PR DESCRIPTION
The current code was checking for the blood moon on the map the player is viewing, instead the affected pawn being on. It was possible to abuse it by switching maps (if the player had multiple active), or moving pawns out on a caravan and creating a new colony. On top of that, it was detrimental pawns on other maps, since even if they had no blood moon active - they would still get the double hemogen drain.

I've also changed a bit how the patch works - instead of being a postfix that directly modifies the amount of hemogen the pawn has, followed by calling `GeneResourceDrainUtility.PostResourceOffset` - it's now a prefix that just doubles the amount the original method works with. This prevents the double call to `GeneResourceDrainUtility.PostResourceOffset`, as the original method will already work on the correct amount.