### PR TITLE
Make hemogen drain gizmo tooltip show doubled drain during blood moons

### DIFF
--- a/1.4/Source/VanillaRacesExpanded-Sanguophage/VanillaRacesExpanded-Sanguophage/Harmony/GeneGizmo_ResourceHemogen_GetTooltip.cs
+++ b/1.4/Source/VanillaRacesExpanded-Sanguophage/VanillaRacesExpanded-Sanguophage/Harmony/GeneGizmo_ResourceHemogen_GetTooltip.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+using RimWorld;
+
+
+namespace VanillaRacesExpandedSanguophage
+{
+
+
+    [HarmonyPatch(typeof(GeneGizmo_ResourceHemogen))]
+    [HarmonyPatch("GetTooltip")]
+
+    static class GeneGizmo_ResourceHemogen_GetTooltip
+    {
+        private static bool CachedIsBloodMoon = false;
+
+        [HarmonyPrefix]
+        public static void CacheIsBloodMoon(Gene_Resource ___gene)
+        {
+            CachedIsBloodMoon = ___gene.pawn.Map?.GameConditionManager?.ConditionIsActive(InternalDefOf.VRE_BloodMoonCondition) == true;
+        }
+
+
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> ReplaceResourceLossPerDayCall(IEnumerable<CodeInstruction> instr)
+        {
+            MethodInfo target = AccessTools.DeclaredPropertyGetter(typeof(IGeneResourceDrain), nameof(IGeneResourceDrain.ResourceLossPerDay));
+            MethodInfo replacement = AccessTools.DeclaredMethod(typeof(GeneGizmo_ResourceHemogen_GetTooltip), nameof(DoubleResourceDrainDuringBloodmoon));
+
+            return instr.MethodReplacer(target, replacement);
+        }
+
+
+        public static float DoubleResourceDrainDuringBloodmoon(IGeneResourceDrain resource)
+        {
+            float loss = resource.ResourceLossPerDay;
+
+            if (CachedIsBloodMoon && loss > 0)
+                loss *= 2;
+            return loss;
+        }
+    }
+}

--- a/1.4/Source/VanillaRacesExpanded-Sanguophage/VanillaRacesExpanded-Sanguophage/VanillaRacesExpanded-Sanguophage.csproj
+++ b/1.4/Source/VanillaRacesExpanded-Sanguophage/VanillaRacesExpanded-Sanguophage/VanillaRacesExpanded-Sanguophage.csproj
@@ -340,6 +340,7 @@
     <Compile Include="Harmony\CompAbilityEffect_BloodfeederBite_Apply.cs" />
     <Compile Include="Harmony\CompDeathrestBindable_Apply.cs" />
     <Compile Include="Harmony\FloatMenuMakerMap_AddHumanlikeOrders.cs" />
+    <Compile Include="Harmony\GeneGizmo_ResourceHemogen_GetTooltip.cs" />
     <Compile Include="Harmony\GeneGizmo_Resource_DrawLabel.cs" />
     <Compile Include="Harmony\GeneGizmo_Resource_GizmoOnGUI.cs" />
     <Compile Include="Harmony\GeneResourceDrainUtility_OffsetResource.cs" />


### PR DESCRIPTION
I understand this is probably something rather rather insignificant that received a transpiler, so I wouldn't be surprised if it got rejected.

I've patched GeneGizmo_ResourceHemogen.GetTooltip to:
- Cache if the blood moon is active
- Replace the call to IGeneResourceDrain.ResourceLossPerDay with our custom one
- Inside of our custom replaced methods, we call IGeneResourceDrain.ResourceLossPerDay and return the value as doubled if the blood moon is active (based on the value that was cached earlier)

I've tried to follow the same style as in the rest of the project, however if something doesn't match it - let me know and I'll change it. Same with any additional changes, if any are required.